### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,22 +24,12 @@
       "inputs": ["production", "^production"]
     }
   },
-  "nxCloudId": "674f53c7d65714bfee93e43f",
-  "nxCloudUrl": "https://staging.nx.app",
+  "nxCloudId": "6786c656c79278ce38ec094f",
+  "nxCloudUrl": "http://localhost:4202",
   "test": "2",
   "plugins": [
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
-    {
-      "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      }
-    }
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    { "plugin": "@nx/jest/plugin", "options": { "targetName": "test" } }
   ],
   "defaultBase": "origin/main"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
http://localhost:4202/orgs/6786c53fc79278ce38ec094d/workspaces/6786c656c79278ce38ec094f

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.